### PR TITLE
Add link to documentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,6 @@ TWITTER_API_CONSEC = 'API key secret'
 `django/font.ttf`
 
 `nuxt/common.js` is defining `API_BASE_URL`.
+
+## Documentation
+https://docs.contour.so/cordx56/tweet-generator/getting-started


### PR DESCRIPTION
Hi there!

My name is Leo, a CS student at Brown building an automated platform for editable codebase documentation.

I generated documentation for this repository and placed a link in the README. Please feel free to try it out and let me know what you think!